### PR TITLE
Update Express to v5.0.0

### DIFF
--- a/examples/express-benchmark-app.js
+++ b/examples/express-benchmark-app.js
@@ -294,8 +294,8 @@ app.get('/mixed', (req, res) => {
   }
 })
 
-// Batch endpoint - runs multiple operations of the same type
-app.get('/batch/:type/:count?', (req, res) => {
+// Helper function for batch processing
+function handleBatchRequest (req, res) {
   const { type, count = 5 } = req.params
   const batchCount = Math.min(Math.max(parseInt(count), 1), 20) // Limit between 1-20
 
@@ -350,7 +350,13 @@ app.get('/batch/:type/:count?', (req, res) => {
       timestamp: new Date().toISOString()
     })
   }
-})
+}
+
+// Batch endpoint - runs multiple operations of the same type (with count)
+app.get('/batch/:type/:count', handleBatchRequest)
+
+// Batch endpoint - runs multiple operations of the same type (default count)
+app.get('/batch/:type', handleBatchRequest)
 
 // Root endpoint - provides API documentation
 app.get('/', (req, res) => {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "eslint": "^9.0.0",
-    "express": "^4.19.2",
+    "express": "^5.0.0",
     "helmet": "^8.0.0",
     "light-my-request": "^6.6.0",
     "morgan": "^1.10.0",


### PR DESCRIPTION
## Summary
- Update Express dependency from v4.19.2 to v5.0.0
- Fix route parameter compatibility for Express v5 by replacing optional parameter syntax
- Refactor batch endpoint to use separate routes instead of optional parameters
- All tests passing with Express v5

## Changes
- **package.json**: Update Express from `^4.19.2` to `^5.0.0`
- **examples/express-benchmark-app.js**: 
  - Replace `/batch/:type/:count?` route with separate routes for Express v5 compatibility
  - Add `handleBatchRequest` helper function to handle both `/batch/:type/:count` and `/batch/:type` routes
  - Fix linting issues (space before function parentheses)

## Test plan
- [x] All existing tests pass
- [x] Benchmark app starts successfully with Express v5
- [x] Both `/batch/:type` and `/batch/:type/:count` endpoints work correctly
- [x] No breaking changes to API functionality

This update brings the project up to the latest major version of Express while maintaining backward compatibility for all existing functionality.