### PR TITLE
Improve generate command output with clickable URLs and better formatting

### DIFF
--- a/bin/flame.js
+++ b/bin/flame.js
@@ -161,11 +161,12 @@ async function main () {
         }
 
         const outputFile = args.output || `${path.basename(pprofFile, path.extname(pprofFile))}.html`
+        const profileType = path.basename(pprofFile).includes('heap') ? 'Heap' : 'CPU'
 
-        console.log(`Generating flamegraph from ${pprofFile}...`)
-        const result = await generateFlamegraph(pprofFile, outputFile)
-        console.log(`Flamegraph generated: ${outputFile}`)
-        console.log(result.stdout)
+        console.log(`🔥 Generating ${profileType} flamegraph from ${pprofFile}...`)
+        await generateFlamegraph(pprofFile, outputFile)
+        console.log(`🔥 ${profileType} flamegraph generated: ${outputFile}`)
+        console.log(`🔥 Open file://${path.resolve(outputFile)} in your browser to view the flamegraph`)
         break
       }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -88,7 +88,7 @@ async function generateFlamegraph (pprofPath, outputPath) {
     const cliPath = require.resolve('react-pprof/cli.js')
 
     // Detect if this is a heap profile and use blue/purple colors
-    const isHeapProfile = path.basename(pprofPath).includes('heap-profile')
+    const isHeapProfile = path.basename(pprofPath).includes('heap')
     const args = [cliPath, '--output', outputPath]
 
     if (isHeapProfile) {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -172,8 +172,8 @@ test('integration: full workflow from profiling to flamegraph generation', { ski
 
   // Verify the output contains expected success messages
   assert.ok(
-    generateResult.stdout.includes('Generated HTML output') ||
-    generateResult.stdout.includes('HTML'),
+    generateResult.stdout.includes('flamegraph generated') ||
+    generateResult.stdout.includes('file://'),
     'Should indicate successful HTML generation'
   )
 


### PR DESCRIPTION
## Summary
This PR improves the `generate` command output to match the style and functionality of the `run` command, making it more user-friendly and consistent.

## Changes
- ✨ Add clickable `file://` URLs for generated HTML files (matching `run` command behavior)
- 🎨 Add profile type detection (CPU vs Heap) for better user feedback
- 🔥 Add fire emoji to match `run` command style
- 🔧 Simplify heap profile detection to check for `'heap'` instead of `'heap-profile'`
- 🧪 Update integration tests to match new output format
- 🧹 Remove redundant stdout noise from generate command

## Before
```
Generating flamegraph from cpu-profile-2025-10-10T15-56-04-670Z.pb...
Flamegraph generated: cpu-profile-2025-10-10T15-56-04-670Z.html
<stdout from react-pprof CLI>
```

## After
```
🔥 Generating CPU flamegraph from cpu-profile-2025-10-10T15-56-04-670Z.pb...
🔥 CPU flamegraph generated: cpu-profile-2025-10-10T15-56-04-670Z.html
🔥 Open file:///Users/matteo/repos/flame/cpu-profile-2025-10-10T15-56-04-670Z.html in your browser to view the flamegraph
```

The `file://` URLs are clickable in modern terminals, making it much easier to open the generated flamegraph.

## Test plan
- [x] All existing tests pass
- [x] Integration test updated to check for new output format
- [x] Heap profile detection still works correctly with simplified check
- [x] Manual testing confirms clickable URLs work in terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1332" height="753" alt="Screenshot 2025-10-14 at 12 38 18" src="https://github.com/user-attachments/assets/956cdb0e-3947-4f97-a77b-4200c218e4d5" />
