### PR TITLE
fix pprof@5.15.1 version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
-        "@datadog/pprof": "^5.9.0",
+        "@datadog/pprof": "5.15.1",
         "fastify": "^5.5.0",
         "pprof-format": "^2.2.1",
         "pprof-to-md": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "url": "https://github.com/platformatic/flame/issues"
   },
   "dependencies": {
-    "@datadog/pprof": "^5.9.0",
+    "@datadog/pprof": "5.15.1",
     "fastify": "^5.5.0",
     "pprof-format": "^2.2.1",
     "pprof-to-md": "^0.2.0",


### PR DESCRIPTION
Until this lands: https://github.com/DataDog/pprof-nodejs/commit/2e3ad636041332bb943339b1ac5c47a183508df2 
...we need to fix the pprof version, because 5.16.0,  ships with binding.gyp even if not necessary, so `npm install` try to compile (but this can fail, especially in Docker images building).